### PR TITLE
🧹 Refactor: Remove All Code Comments

### DIFF
--- a/cmd/cluster/clean.go
+++ b/cmd/cluster/clean.go
@@ -29,17 +29,15 @@ var cleanCmd = &cobra.Command{
 			clusterName := args[0]
 			logger.Infoln("Cleaning up resources for cluster '%s'...", clusterName)
 
-			// Delete the cluster
 			if err := client.DeleteCluster(clusterName, &wg); err != nil {
 				logger.Errorln("Failed to clean up cluster: %v", err)
 				return
 			}
-			wg.Wait() // Wait for all goroutines to complete
+			wg.Wait()
 
 			logger.Successln("Successfully cleaned up cluster '%s'", clusterName)
 		}
 
-		// If purge flag is set or no cluster name was provided, purge all deleted instances
 		if cPurge || len(args) == 0 {
 			logger.Infoln("Purging all deleted instances...")
 			if err := client.PurgeNodes(); err != nil {

--- a/cmd/cluster/delete.go
+++ b/cmd/cluster/delete.go
@@ -39,7 +39,7 @@ var (
 				logger.Errorln("Failed to delete cluster: %v", err)
 				return
 			}
-			wg.Wait() // Wait for all goroutines to complete
+			wg.Wait()
 
 			if cDeleteForce {
 				logger.Infoln("Purging deleted instances...")

--- a/cmd/cluster/plugin/add.go
+++ b/cmd/cluster/plugin/add.go
@@ -18,7 +18,6 @@ var addCmd = &cobra.Command{
 	Short: "Add a new plugin",
 	Long:  `Add a new plugin to the cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Get the name of the plugin from the flags
 		c := types.Cluster{
 			Name: cName,
 		}

--- a/cmd/cluster/plugin/remove.go
+++ b/cmd/cluster/plugin/remove.go
@@ -13,7 +13,6 @@ var removeCmd = &cobra.Command{
 	Short: "remove plugin",
 	Long:  `Remove plugin from the cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Get the name of the plugin from the flags
 		c := types.Cluster{
 			Name: cName,
 		}

--- a/internal/installer/helm.go
+++ b/internal/installer/helm.go
@@ -114,12 +114,10 @@ func (h *HelmInstaller) UnInstall(options *InstallOptions) error {
 func (h *HelmInstaller) createHelmActionConfig(namespace string) (*action.Configuration, error) {
 	tmpPath := filepath.Join(os.TempDir(), fmt.Sprintf("kubeconfig-%d", time.Now().UnixNano()))
 	
-	// Use more restrictive permissions for kubeconfig file
 	if err := os.WriteFile(tmpPath, []byte(h.KubeConfig), 0600); err != nil {
 		return nil, fmt.Errorf("failed to write kubeconfig to temp file: %w", err)
 	}
 	
-	// Return the kubeconfig file path for explicit cleanup by the caller
 	settings.KubeConfig = tmpPath
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(settings.RESTClientGetter(), namespace, os.Getenv("HELM_DRIVER"), log.Printf); err != nil {

--- a/internal/plugins/argocd.go
+++ b/internal/plugins/argocd.go
@@ -28,9 +28,8 @@ const (
 	ArgoRepoName        = "argo"
 	ArgocdValuesFileURL = "https://raw.githubusercontent.com/mrgb7/core-infrastructure/refs/heads/main/argocd/argocd-values-local.yaml"
 	
-	// HTTP client configuration
 	HTTPTimeoutSeconds = 30
-	MaxResponseSize    = 10 * 1024 * 1024 // 10MB max response size
+	MaxResponseSize    = 10 * 1024 * 1024
 )
 
 func (a *Argocd) GetName() string {
@@ -79,12 +78,10 @@ func (a *Argocd) GetInstaller() (installer.Installer, error) {
 }
 
 func (a *Argocd) getValuesContent() (map[string]interface{}, error) {
-	// Validate URL
 	if _, err := url.Parse(ArgocdValuesFileURL); err != nil {
 		return nil, fmt.Errorf("invalid values file URL: %w", err)
 	}
 	
-	// Create HTTP client with timeout
 	httpClient := &http.Client{
 		Timeout: HTTPTimeoutSeconds * time.Second,
 	}
@@ -107,14 +104,12 @@ func (a *Argocd) getValuesContent() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("failed to fetch values file: HTTP %d %s", resp.StatusCode, resp.Status)
 	}
 	
-	// Limit response size to prevent DoS
 	limitedReader := io.LimitReader(resp.Body, MaxResponseSize)
 	content, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 	
-	// Log content hash for integrity verification (optional)
 	hash := sha256.Sum256(content)
 	logger.Debugf("ArgoCD values file SHA256: %x", hash)
 	

--- a/internal/plugins/loadbalancer.go
+++ b/internal/plugins/loadbalancer.go
@@ -189,7 +189,6 @@ func (l *LoadBalancer) deleteValidationWebhookConfig() error {
 }
 
 func (l *LoadBalancer) getIPRange() (string, error) {
-	// Later on we need to calculate the range based on the master cluster ip and dhcp
 	ipParts := strings.Split(l.MasterClusterIP, ".")
 	dhcp := ipParts[:3]
 	start := fmt.Sprintf("%s.100", strings.Join(dhcp, "."))

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,6 +1,3 @@
-// Package logger provides colored logging utilities for console output.
-// It supports different log levels (info, warn, error, debug, success) with color coding
-// and provides fatal logging that exits the application.
 package logger
 
 import (
@@ -18,93 +15,75 @@ var (
 	successColor = color.New(color.FgGreen, color.Bold)
 )
 
-// Info prints an informational message in green color.
 func Info(format string, args ...interface{}) {
 	infoColor.Printf(format, args...)
 }
 
-// Infof prints an informational message in green color (alias for Info).
 func Infof(format string, args ...interface{}) {
 	infoColor.Printf(format, args...)
 }
 
-// Infoln prints an informational message in green color with a newline.
 func Infoln(format string, args ...interface{}) {
 	infoColor.Printf(format+"\n", args...)
 }
 
-// Warn prints a warning message in yellow color.
 func Warn(format string, args ...interface{}) {
 	warnColor.Printf(format, args...)
 }
 
-// Warnf prints a warning message in yellow color (alias for Warn).
 func Warnf(format string, args ...interface{}) {
 	warnColor.Printf(format, args...)
 }
 
-// Warnln prints a warning message in yellow color with a newline.
 func Warnln(format string, args ...interface{}) {
 	warnColor.Printf(format+"\n", args...)
 }
 
-// Error prints an error message in red color.
 func Error(format string, args ...interface{}) {
 	errorColor.Printf(format, args...)
 }
 
-// Errorf prints an error message in red color (alias for Error).
 func Errorf(format string, args ...interface{}) {
 	errorColor.Printf(format, args...)
 }
 
-// Errorln prints an error message in red color with a newline.
 func Errorln(format string, args ...interface{}) {
 	errorColor.Printf(format+"\n", args...)
 }
 
-// Debug prints a debug message in cyan color.
 func Debug(format string, args ...interface{}) {
 	debugColor.Printf(format, args...)
 }
 
-// Debugf prints a debug message in cyan color (alias for Debug).
 func Debugf(format string, args ...interface{}) {
 	debugColor.Printf(format, args...)
 }
 
-// Debugln prints a debug message in cyan color with a newline.
 func Debugln(format string, args ...interface{}) {
 	debugColor.Printf(format+"\n", args...)
 }
 
-// Success prints a success message in bold green color.
 func Success(format string, args ...interface{}) {
 	successColor.Printf(format, args...)
 }
 
-// Successf prints a success message in bold green color (alias for Success).
 func Successf(format string, args ...interface{}) {
 	successColor.Printf(format, args...)
 }
 
-// Successln prints a success message in bold green color with a newline.
 func Successln(format string, args ...interface{}) {
 	successColor.Printf(format+"\n", args...)
 }
 
-// Fatal prints an error message in red color and exits the application with code 1.
 func Fatal(format string, args ...interface{}) {
 	errorColor.Printf(format+"\n", args...)
 	os.Exit(1)
 }
 
-// Print prints a message without color formatting.
 func Print(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
-// Println prints a message without color formatting with a newline.
 func Println(format string, args ...interface{}) {
 	fmt.Printf(format+"\n", args...)
 }

--- a/types/Cluster.go
+++ b/types/Cluster.go
@@ -39,7 +39,6 @@ func (c *Cluster) GetWorkers() []*Node {
 func (c *Cluster) SetKubeConfig() error {
 	masterNodeName := fmt.Sprintf("%s-master", c.Name)
 	cl := multipass.NewMultipassClient()
-	// Get the master node IP
 	masterIP, err := cl.GetNodeIP(masterNodeName)
 	if err != nil {
 		return fmt.Errorf("failed to get master node IP: %w", err)
@@ -48,7 +47,6 @@ func (c *Cluster) SetKubeConfig() error {
 	if err != nil {
 		return fmt.Errorf("failed to get kubeconfig: %w", err)
 	}
-	// Replace the server address in the kubeconfig with the master node masterIP
 	res = strings.ReplaceAll(res, "127.0.0.1", masterIP)
 	c.KubeConfig = res
 	return nil
@@ -57,7 +55,6 @@ func (c *Cluster) SetKubeConfig() error {
 func (c *Cluster) GetMasterIP() string {
 	masterNodeName := fmt.Sprintf("%s-master", c.Name)
 	cl := multipass.NewMultipassClient()
-	// Get the master node IP
 	masterIP, err := cl.GetNodeIP(masterNodeName)
 	if err != nil {
 		return ""


### PR DESCRIPTION
This PR removes all code comments from the Go codebase to create a cleaner, comment-free version. Changes include: removal of all single-line comments, package documentation, function documentation, and fixing URLs that were corrupted during the process. Code still compiles and functions correctly with all functionality preserved.