### PR TITLE
Fix High-Priority Bad Practices

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -20,7 +20,7 @@ examples and usage of using your application.`,
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		logger.Errorln("%v", err)
+		logger.Errorln("Error: %v", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -15,75 +15,93 @@ var (
 	successColor = color.New(color.FgGreen, color.Bold)
 )
 
+// Info prints info message with format
 func Info(format string, args ...interface{}) {
 	infoColor.Printf(format, args...)
 }
 
+// Infof is an alias for Info for consistency
 func Infof(format string, args ...interface{}) {
-	infoColor.Printf(format, args...)
+	Info(format, args...)
 }
 
+// Infoln prints info message with newline
 func Infoln(format string, args ...interface{}) {
 	infoColor.Printf(format+"\n", args...)
 }
 
+// Warn prints warning message with format
 func Warn(format string, args ...interface{}) {
 	warnColor.Printf(format, args...)
 }
 
+// Warnf is an alias for Warn for consistency
 func Warnf(format string, args ...interface{}) {
-	warnColor.Printf(format, args...)
+	Warn(format, args...)
 }
 
+// Warnln prints warning message with newline
 func Warnln(format string, args ...interface{}) {
 	warnColor.Printf(format+"\n", args...)
 }
 
+// Error prints error message with format
 func Error(format string, args ...interface{}) {
 	errorColor.Printf(format, args...)
 }
 
+// Errorf is an alias for Error for consistency
 func Errorf(format string, args ...interface{}) {
-	errorColor.Printf(format, args...)
+	Error(format, args...)
 }
 
+// Errorln prints error message with newline
 func Errorln(format string, args ...interface{}) {
 	errorColor.Printf(format+"\n", args...)
 }
 
+// Debug prints debug message with format
 func Debug(format string, args ...interface{}) {
 	debugColor.Printf(format, args...)
 }
 
+// Debugf is an alias for Debug for consistency
 func Debugf(format string, args ...interface{}) {
-	debugColor.Printf(format, args...)
+	Debug(format, args...)
 }
 
+// Debugln prints debug message with newline
 func Debugln(format string, args ...interface{}) {
 	debugColor.Printf(format+"\n", args...)
 }
 
+// Success prints success message with format
 func Success(format string, args ...interface{}) {
 	successColor.Printf(format, args...)
 }
 
+// Successf is an alias for Success for consistency
 func Successf(format string, args ...interface{}) {
-	successColor.Printf(format, args...)
+	Success(format, args...)
 }
 
+// Successln prints success message with newline
 func Successln(format string, args ...interface{}) {
 	successColor.Printf(format+"\n", args...)
 }
 
+// Fatal prints error message and exits
 func Fatal(format string, args ...interface{}) {
 	errorColor.Printf(format+"\n", args...)
 	os.Exit(1)
 }
 
+// Print prints plain message with format
 func Print(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
+// Println prints plain message with newline
 func Println(format string, args ...interface{}) {
 	fmt.Printf(format+"\n", args...)
 }


### PR DESCRIPTION
This PR addresses high-priority bad practices in the codebase. Key changes: 1) Fix function naming typo ExcuteShell to ExecuteShell, 2) Add proper constants for magic numbers and limits, 3) Create ClusterConfig struct to encapsulate global flags, 4) Add Client interface for MultipassClient for better testability, 5) Refactor long createCmd.Run function into smaller focused functions, 6) Standardize error handling and wrapping patterns, 7) Clean up redundant logger functions with proper documentation, 8) Remove redundant error logging before returns, 9) Add workerError type at package level for better scope management. All changes improve code maintainability, testability, and readability while maintaining backward compatibility.