### PR TITLE
feat: add cluster list command to display existing clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ playground version --verbose
 ### Basic Commands
 
 ```bash
+# List all existing clusters
+playground cluster list
+
 # Create a single-node cluster
 playground cluster create --name my-cluster
 

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -16,4 +16,5 @@ func init() {
 	ClusterCmd.AddCommand(createCmd)
 	ClusterCmd.AddCommand(deleteCmd)
 	ClusterCmd.AddCommand(cleanCmd)
+	ClusterCmd.AddCommand(listCmd)
 }

--- a/cmd/cluster/list.go
+++ b/cmd/cluster/list.go
@@ -1,0 +1,37 @@
+package cluster
+
+import (
+	"github.com/mrgb7/playground/internal/multipass"
+	"github.com/mrgb7/playground/pkg/logger"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all existing clusters",
+	Long:  `List all existing clusters by finding multipass instances ending with '-master'`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := multipass.NewMultipassClient()
+
+		if !client.IsMultipassInstalled() {
+			logger.Errorln("Error: Multipass is not installed or not in PATH. Please install Multipass first.")
+			return
+		}
+
+		clusters, err := client.ListClusters()
+		if err != nil {
+			logger.Errorln("Failed to list clusters: %v", err)
+			return
+		}
+
+		if len(clusters) == 0 {
+			logger.Infoln("No clusters found.")
+			return
+		}
+
+		logger.Infoln("Available clusters:")
+		for _, cluster := range clusters {
+			logger.Infoln("  - %s", cluster)
+		}
+	},
+} 

--- a/cmd/cluster/list.go
+++ b/cmd/cluster/list.go
@@ -35,4 +35,3 @@ var listCmd = &cobra.Command{
 		}
 	},
 }
-

--- a/cmd/cluster/list.go
+++ b/cmd/cluster/list.go
@@ -34,4 +34,5 @@ var listCmd = &cobra.Command{
 			logger.Infoln("  - %s", cluster)
 		}
 	},
-} 
+}
+

--- a/cmd/cluster/list_test.go
+++ b/cmd/cluster/list_test.go
@@ -1,0 +1,25 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/mrgb7/playground/internal/multipass"
+)
+
+func TestListClusters(t *testing.T) {
+	client := multipass.NewMultipassClient()
+	
+	// Check if multipass is installed before running the test
+	if !client.IsMultipassInstalled() {
+		t.Skip("Multipass is not installed, skipping test")
+	}
+
+	clusters, err := client.ListClusters()
+	if err != nil {
+		t.Fatalf("ListClusters failed: %v", err)
+	}
+
+	// The test should pass regardless of whether clusters exist or not
+	// We just verify that the method doesn't return an error
+	t.Logf("Found %d clusters: %v", len(clusters), clusters)
+} 

--- a/cmd/cluster/list_test.go
+++ b/cmd/cluster/list_test.go
@@ -9,7 +9,6 @@ import (
 func TestListClusters(t *testing.T) {
 	client := multipass.NewMultipassClient()
 	
-	// Check if multipass is installed before running the test
 	if !client.IsMultipassInstalled() {
 		t.Skip("Multipass is not installed, skipping test")
 	}
@@ -19,7 +18,5 @@ func TestListClusters(t *testing.T) {
 		t.Fatalf("ListClusters failed: %v", err)
 	}
 
-	// The test should pass regardless of whether clusters exist or not
-	// We just verify that the method doesn't return an error
 	t.Logf("Found %d clusters: %v", len(clusters), clusters)
 } 

--- a/cmd/cluster/list_test.go
+++ b/cmd/cluster/list_test.go
@@ -20,4 +20,3 @@ func TestListClusters(t *testing.T) {
 
 	t.Logf("Found %d clusters: %v", len(clusters), clusters)
 }
-

--- a/cmd/cluster/list_test.go
+++ b/cmd/cluster/list_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListClusters(t *testing.T) {
 	client := multipass.NewMultipassClient()
-	
+
 	if !client.IsMultipassInstalled() {
 		t.Skip("Multipass is not installed, skipping test")
 	}
@@ -19,4 +19,5 @@ func TestListClusters(t *testing.T) {
 	}
 
 	t.Logf("Found %d clusters: %v", len(clusters), clusters)
-} 
+}
+

--- a/internal/multipass/client.go
+++ b/internal/multipass/client.go
@@ -267,7 +267,8 @@ func (m *MultipassClient) ExecuteShell(name string, command string) (string, err
 }
 
 func (m *MultipassClient) ExecuteShellWithTimeout(name string, command string, timeoutSeconds int,
-	envs ...string) (string, error) {
+	envs ...string,
+) (string, error) {
 	ctx := context.Background()
 	var cancel context.CancelFunc
 
@@ -294,7 +295,6 @@ func (m *MultipassClient) ExecuteShellWithTimeout(name string, command string, t
 
 	return stdout.String(), nil
 }
-
 
 func (m *MultipassClient) ListClusters() ([]string, error) {
 	var list MultiPassList

--- a/internal/multipass/client.go
+++ b/internal/multipass/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/mrgb7/playground/pkg/logger"
 )
 
-// Client defines the interface for multipass operations
 type Client interface {
 	IsMultipassInstalled() bool
 	CreateCluster(clusterName string, nodeCount int, wg *sync.WaitGroup) error
@@ -65,7 +64,6 @@ func NewMultipassClient() *MultipassClient {
 }
 
 func (m *MultipassClient) IsMultipassInstalled() bool {
-	// Binary path is controlled, this is a legitimate multipass CLI call
 	cmd := exec.Command(m.BinaryPath, "--version") //nolint:gosec
 	err := cmd.Run()
 	return err == nil
@@ -131,7 +129,6 @@ func (m *MultipassClient) CreateCluster(clusterName string, nodeCount int, wg *s
 
 func (m *MultipassClient) DeleteCluster(clusterName string, wg *sync.WaitGroup) error {
 	var list MultiPassList
-	// Binary path is controlled, this is a legitimate multipass CLI call
 	cmd := exec.Command(m.BinaryPath, "list", "--format", "json") //nolint:gosec
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -197,7 +194,6 @@ func (m *MultipassClient) CreateNode(name string, cpus int, memory string, disk 
 	}
 
 	logger.Debugln("Creating node: %s with %d CPUs, %s memory, %s disk", name, cpus, memory, disk)
-	// Binary path is controlled, this is a legitimate multipass CLI call
 	cmd := exec.Command(m.BinaryPath, args...) //nolint:gosec
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -211,7 +207,6 @@ func (m *MultipassClient) CreateNode(name string, cpus int, memory string, disk 
 }
 
 func (m *MultipassClient) DeleteNode(name string) error {
-	// Binary path is controlled, this is a legitimate multipass CLI call
 	cmd := exec.Command(m.BinaryPath, "delete", name) //nolint:gosec
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -240,7 +235,6 @@ func (m *MultipassClient) PurgeNodes() error {
 }
 
 func (m *MultipassClient) GetNodeIP(name string) (string, error) {
-	// Binary path is controlled, this is a legitimate multipass CLI call
 	cmd := exec.Command(m.BinaryPath, "info", name, "--format", "json") //nolint:gosec
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -282,7 +276,6 @@ func (m *MultipassClient) ExecuteShellWithTimeout(name string, command string, t
 		defer cancel()
 	}
 
-	// Binary path is controlled, this is a legitimate multipass CLI call
 	cmd := exec.CommandContext(ctx, m.BinaryPath, "exec", name, "--", "bash", "-c", command) //nolint:gosec
 	cmd.Env = append(os.Environ(), envs...)
 	var stdout, stderr bytes.Buffer
@@ -302,11 +295,9 @@ func (m *MultipassClient) ExecuteShellWithTimeout(name string, command string, t
 	return stdout.String(), nil
 }
 
-// ListClusters returns a list of cluster names by finding multipass instances ending with "-master"
-// and extracting the cluster name prefix (e.g., "playground-test-master" -> "playground-test")
+
 func (m *MultipassClient) ListClusters() ([]string, error) {
 	var list MultiPassList
-	// Binary path is controlled, this is a legitimate multipass CLI call
 	cmd := exec.Command(m.BinaryPath, "list", "--format", "json") //nolint:gosec
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -322,9 +313,7 @@ func (m *MultipassClient) ListClusters() ([]string, error) {
 	seenClusters := make(map[string]bool) // To avoid duplicates
 
 	for _, instance := range list.List {
-		// Check if the instance name ends with "-master"
 		if strings.HasSuffix(instance.Name, "-master") {
-			// Extract cluster name by removing the "-master" suffix
 			clusterName := strings.TrimSuffix(instance.Name, "-master")
 			if !seenClusters[clusterName] {
 				clusters = append(clusters, clusterName)

--- a/internal/multipass/client_test.go
+++ b/internal/multipass/client_test.go
@@ -19,13 +19,11 @@ func TestNewMultipassClient(t *testing.T) {
 func TestMultipassClient_IsMultipassInstalled(t *testing.T) {
 	client := NewMultipassClient()
 
-	// Test with invalid binary path
 	client.BinaryPath = "nonexistent-binary"
 	if client.IsMultipassInstalled() {
 		t.Error("Expected IsMultipassInstalled() to return false for nonexistent binary")
 	}
 
-	// Test with valid command (assuming 'echo' exists on most systems)
 	client.BinaryPath = "echo"
 	if !client.IsMultipassInstalled() {
 		t.Error("Expected IsMultipassInstalled() to return true for 'echo' command")
@@ -33,7 +31,6 @@ func TestMultipassClient_IsMultipassInstalled(t *testing.T) {
 }
 
 func TestConstants(t *testing.T) {
-	// Test that constants are properly defined
 	if DefaultMasterCPUs <= 0 {
 		t.Errorf("DefaultMasterCPUs should be positive, got: %d", DefaultMasterCPUs)
 	}
@@ -63,7 +60,6 @@ func TestMultipassClient_CreateNode_ValidatesInput(t *testing.T) {
 	client := NewMultipassClient()
 	client.BinaryPath = "nonexistent-binary" // Ensure it fails for the right reason
 
-	// Test with empty node name
 	err := client.CreateNode("", 1, "1G", "5G")
 	if err == nil {
 		t.Error("Expected CreateNode to fail with empty node name")


### PR DESCRIPTION
This PR adds a new cluster list command that displays all existing clusters by filtering multipass instances ending with -master suffix.