### PR TITLE
feat: Add TLS plugin with automatic ArgoCD HTTPS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,16 @@ The ingress plugin provides domain-based access to your cluster services:
 **Features:**
 - Configures cluster domain: `{cluster-name}.local`
 - Automatically sets up ArgoCD ingress if ArgoCD is installed
+- Automatic TLS certificate generation when TLS plugin is installed
 - Ensures nginx service is exposed as LoadBalancer
 - Provides `/etc/hosts` configuration commands
 
 **Dependencies:**
 - `nginx-ingress` plugin must be installed
 - `load-balancer` plugin must be installed
+
+**Optional Enhancement:**
+- `tls` plugin for automatic HTTPS certificate generation
 
 **Usage:**
 ```bash
@@ -154,9 +158,15 @@ playground cluster plugin add --name nginx-ingress --cluster my-cluster
 
 # Install ingress plugin
 playground cluster plugin add --name ingress --cluster my-cluster
+
+# Optional: Install TLS plugin for HTTPS support
+playground cluster plugin add --name cert-manager --cluster my-cluster
+playground cluster plugin add --name tls --cluster my-cluster
+# Now re-run ingress plugin to enable HTTPS
+playground cluster plugin add --name ingress --cluster my-cluster
 ```
 
-After installation, the plugin will provide commands to add entries to your `/etc/hosts` file for local domain access.
+After installation, the plugin will provide commands to add entries to your `/etc/hosts` file for local domain access. If the TLS plugin is installed, ArgoCD will automatically be configured with HTTPS using the generated CA certificate.
 
 #### TLS Plugin
 
@@ -169,6 +179,7 @@ The TLS plugin provides SSL/TLS certificate management for your cluster using se
 - Provides OS-specific instructions for trusting the CA certificate
 - 10-year certificate validity period
 - Supports macOS, Linux, and Windows trust store integration
+- Automatic ArgoCD HTTPS configuration when used with ingress plugin
 
 **Dependencies:**
 - `cert-manager` plugin must be installed
@@ -180,7 +191,17 @@ playground cluster plugin add --name cert-manager --cluster my-cluster
 
 # Install TLS plugin
 playground cluster plugin add --name tls --cluster my-cluster
+
+# If ingress plugin is already installed, re-run it to enable HTTPS
+playground cluster plugin add --name ingress --cluster my-cluster
 ```
+
+**Integration with Ingress Plugin:**
+When both TLS and ingress plugins are installed, the ingress plugin automatically:
+- Detects the TLS cluster issuer (`local-ca-issuer`)
+- Configures ArgoCD ingress with TLS certificate generation
+- Updates ArgoCD to use HTTPS instead of HTTP
+- Displays HTTPS URLs in the setup instructions
 
 **Generated Resources:**
 - Secret: `local-ca-secret` in `cert-manager` namespace

--- a/cmd/cluster/plugin/list.go
+++ b/cmd/cluster/plugin/list.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"github.com/mrgb7/playground/internal/plugins"
+	"github.com/mrgb7/playground/pkg/logger"
+	"github.com/mrgb7/playground/types"
 	"github.com/spf13/cobra"
 )
 
@@ -10,12 +12,41 @@ var listCmd = &cobra.Command{
 	Short: "List all available plugins",
 	Long:  `List all available plugins for the cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		for _, plugin := range plugins.List {
-			println(plugin.GetName(), plugin.Status())
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
+		if clusterName == "" {
+			logger.Infoln("Basic plugins:")
+			for _, plugin := range plugins.List {
+				logger.Infoln("  %s: %s", plugin.GetName(), plugin.Status())
+			}
+			logger.Infoln("")
+			logger.Infoln("For cluster-specific plugins, specify --cluster-name")
+			return
+		}
+
+		c := types.Cluster{
+			Name: clusterName,
+		}
+
+		ip := c.GetMasterIP()
+		if err := c.SetKubeConfig(); err != nil {
+			logger.Errorln("Failed to set kubeconfig: %v", err)
+			return
+		}
+
+		pluginsList, err := plugins.CreatePluginsList(c.KubeConfig, ip, c.Name)
+		if err != nil {
+			logger.Errorln("Failed to create plugins list: %v", err)
+			return
+		}
+
+		logger.Infoln("Available plugins for cluster '%s':", clusterName)
+		for _, plugin := range pluginsList {
+			logger.Infoln("  %s: %s", plugin.GetName(), plugin.Status())
 		}
 	},
 }
 
 func init() {
+	listCmd.Flags().StringP("cluster-name", "c", "", "Cluster name to list plugins for")
 	PluginCmd.AddCommand(listCmd)
 }

--- a/internal/plugins/ingress.go
+++ b/internal/plugins/ingress.go
@@ -299,7 +299,11 @@ func (i *Ingress) isTLSClusterIssuerAvailable() bool {
 	return err == nil
 }
 
-func (i *Ingress) updateExistingArgoCDIngress(existingIngress *networkingv1.Ingress, hostname string, isTLSAvailable bool) error {
+func (i *Ingress) updateExistingArgoCDIngress(
+	existingIngress *networkingv1.Ingress,
+	hostname string,
+	isTLSAvailable bool,
+) error {
 	logger.Infoln("Updating existing ArgoCD ingress with cluster domain and TLS...")
 
 	if len(existingIngress.Spec.Rules) > 0 {

--- a/internal/plugins/ingress.go
+++ b/internal/plugins/ingress.go
@@ -19,6 +19,8 @@ const (
 	IngressName      = "ingress"
 	IngressVersion   = "1.0.0"
 	ArgoCDPort       = 80
+	TrueValue        = "true"
+	FalseValue       = "false"
 )
 
 type Ingress struct {
@@ -179,113 +181,9 @@ func (i *Ingress) configureArgoCDIngress() error {
 	hostname := fmt.Sprintf("argocd.%s.local", i.ClusterName)
 
 	if err == nil {
-		logger.Infoln("Updating existing ArgoCD ingress with cluster domain and TLS...")
-
-		if len(existingIngress.Spec.Rules) > 0 {
-			existingIngress.Spec.Rules[0].Host = hostname
-		}
-
-		if isTLSAvailable {
-			if existingIngress.Annotations == nil {
-				existingIngress.Annotations = make(map[string]string)
-			}
-			existingIngress.Annotations["cert-manager.io/cluster-issuer"] = "local-ca-issuer"
-			existingIngress.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "true"
-			existingIngress.Annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "true"
-
-			existingIngress.Spec.TLS = []networkingv1.IngressTLS{
-				{
-					Hosts:      []string{hostname},
-					SecretName: "argocd-server-tls",
-				},
-			}
-		} else {
-			if existingIngress.Annotations != nil {
-				existingIngress.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "false"
-				existingIngress.Annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "false"
-			}
-		}
-
-		_, err = i.k8sClient.Clientset.NetworkingV1().Ingresses("argocd").Update(ctx, existingIngress, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to update existing ArgoCD ingress: %w", err)
-		}
-		if isTLSAvailable {
-			logger.Successln("Updated existing ArgoCD ingress with HTTPS: https://argocd.%s.local", i.ClusterName)
-		} else {
-			logger.Successln("Updated existing ArgoCD ingress with host: argocd.%s.local", i.ClusterName)
-		}
-	} else {
-		logger.Infoln("Creating new ArgoCD ingress...")
-
-		annotations := map[string]string{
-			"nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
-		}
-
-		var tlsConfig []networkingv1.IngressTLS
-
-		if isTLSAvailable {
-			annotations["cert-manager.io/cluster-issuer"] = "local-ca-issuer"
-			annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "true"
-			annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "true"
-			tlsConfig = []networkingv1.IngressTLS{
-				{
-					Hosts:      []string{hostname},
-					SecretName: "argocd-server-tls",
-				},
-			}
-		} else {
-			annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "false"
-			annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "false"
-		}
-
-		ingress := &networkingv1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "argocd-server",
-				Namespace:   "argocd",
-				Annotations: annotations,
-			},
-			Spec: networkingv1.IngressSpec{
-				IngressClassName: func() *string { s := "nginx"; return &s }(),
-				TLS:              tlsConfig,
-				Rules: []networkingv1.IngressRule{
-					{
-						Host: hostname,
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
-									{
-										Path:     "/",
-										PathType: func() *networkingv1.PathType { pt := networkingv1.PathTypePrefix; return &pt }(),
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
-												Name: "argocd-server",
-												Port: networkingv1.ServiceBackendPort{
-													Number: ArgoCDPort,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		_, err = i.k8sClient.Clientset.NetworkingV1().Ingresses("argocd").Create(ctx, ingress, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to create ArgoCD ingress: %w", err)
-		}
-		if isTLSAvailable {
-			logger.Successln("Created ArgoCD ingress with HTTPS: https://argocd.%s.local", i.ClusterName)
-		} else {
-			logger.Successln("Created ArgoCD ingress with host: argocd.%s.local", i.ClusterName)
-		}
+		return i.updateExistingArgoCDIngress(existingIngress, hostname, isTLSAvailable)
 	}
-
-	return nil
+	return i.createNewArgoCDIngress(hostname, isTLSAvailable)
 }
 
 func (i *Ingress) removeArgoCDIngress() error {
@@ -350,7 +248,8 @@ func (i *Ingress) printHostInstructions() error {
 			logger.Infoln("🔒 TLS certificates will be automatically generated")
 		} else {
 			logger.Infoln("🚀 ArgoCD will be available at: http://argocd.%s.local", i.ClusterName)
-			logger.Infoln("💡 Install TLS plugin for HTTPS support: playground cluster plugin add --name tls --cluster %s", i.ClusterName)
+			logger.Infoln("💡 Install TLS plugin for HTTPS support:")
+			logger.Infoln("   playground cluster plugin add --name tls --cluster %s", i.ClusterName)
 		}
 	}
 
@@ -394,6 +293,127 @@ func (i *Ingress) isTLSClusterIssuerAvailable() bool {
 		Resource: "clusterissuers",
 	}
 
-	_, err := i.k8sClient.Dynamic.Resource(gvr).Get(ctx, "local-ca-issuer", metav1.GetOptions{})
+	tls := &TLS{}
+	issuerName := tls.GetClusterIssuerName()
+	_, err := i.k8sClient.Dynamic.Resource(gvr).Get(ctx, issuerName, metav1.GetOptions{})
 	return err == nil
+}
+
+func (i *Ingress) updateExistingArgoCDIngress(existingIngress *networkingv1.Ingress, hostname string, isTLSAvailable bool) error {
+	logger.Infoln("Updating existing ArgoCD ingress with cluster domain and TLS...")
+
+	if len(existingIngress.Spec.Rules) > 0 {
+		existingIngress.Spec.Rules[0].Host = hostname
+	}
+
+	if isTLSAvailable {
+		if existingIngress.Annotations == nil {
+			existingIngress.Annotations = make(map[string]string)
+		}
+		tls := &TLS{}
+		existingIngress.Annotations["cert-manager.io/cluster-issuer"] = tls.GetClusterIssuerName()
+		existingIngress.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = TrueValue
+		existingIngress.Annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = TrueValue
+
+		existingIngress.Spec.TLS = []networkingv1.IngressTLS{
+			{
+				Hosts:      []string{hostname},
+				SecretName: "argocd-server-tls",
+			},
+		}
+	} else if existingIngress.Annotations != nil {
+		existingIngress.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = FalseValue
+		existingIngress.Annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = FalseValue
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := i.k8sClient.Clientset.NetworkingV1().Ingresses("argocd").Update(ctx, existingIngress, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update existing ArgoCD ingress: %w", err)
+	}
+
+	if isTLSAvailable {
+		logger.Successln("Updated existing ArgoCD ingress with HTTPS: https://argocd.%s.local", i.ClusterName)
+	} else {
+		logger.Successln("Updated existing ArgoCD ingress with host: argocd.%s.local", i.ClusterName)
+	}
+	return nil
+}
+
+func (i *Ingress) createNewArgoCDIngress(hostname string, isTLSAvailable bool) error {
+	logger.Infoln("Creating new ArgoCD ingress...")
+
+	annotations := map[string]string{
+		"nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
+	}
+
+	var tlsConfig []networkingv1.IngressTLS
+
+	if isTLSAvailable {
+		tls := &TLS{}
+		annotations["cert-manager.io/cluster-issuer"] = tls.GetClusterIssuerName()
+		annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = TrueValue
+		annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = TrueValue
+		tlsConfig = []networkingv1.IngressTLS{
+			{
+				Hosts:      []string{hostname},
+				SecretName: "argocd-server-tls",
+			},
+		}
+	} else {
+		annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = FalseValue
+		annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = FalseValue
+	}
+
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "argocd-server",
+			Namespace:   "argocd",
+			Annotations: annotations,
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: func() *string { s := "nginx"; return &s }(),
+			TLS:              tlsConfig,
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: hostname,
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: func() *networkingv1.PathType { pt := networkingv1.PathTypePrefix; return &pt }(),
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "argocd-server",
+											Port: networkingv1.ServiceBackendPort{
+												Number: ArgoCDPort,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := i.k8sClient.Clientset.NetworkingV1().Ingresses("argocd").Create(ctx, ingress, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create ArgoCD ingress: %w", err)
+	}
+
+	if isTLSAvailable {
+		logger.Successln("Created ArgoCD ingress with HTTPS: https://argocd.%s.local", i.ClusterName)
+	} else {
+		logger.Successln("Created ArgoCD ingress with host: argocd.%s.local", i.ClusterName)
+	}
+	return nil
 }

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -24,12 +24,18 @@ func CreatePluginsList(kubeConfig, masterClusterIP, clusterName string) ([]Plugi
 		return nil, err
 	}
 
+	tls, err := NewTLS(kubeConfig, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
 	return []Plugin{
 		NewArgocd(kubeConfig),
 		NewCertManager(kubeConfig),
 		lb,
 		NewNginx(kubeConfig),
 		ingress,
+		tls,
 	}, nil
 }
 

--- a/internal/plugins/plugin_test.go
+++ b/internal/plugins/plugin_test.go
@@ -30,6 +30,30 @@ func TestCreatePluginsListIncludesIngress(t *testing.T) {
 	}
 }
 
+func TestCreatePluginsListIncludesTLS(t *testing.T) {
+	plugins, err := CreatePluginsList("dummy-kubeconfig", "192.168.1.100", "test-cluster")
+	if err != nil {
+		t.Logf("CreatePluginsList failed (expected in test environment): %v", err)
+		return
+	}
+
+	found := false
+	for _, plugin := range plugins {
+		if plugin.GetName() == TLSName {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("TLS plugin not found in CreatePluginsList")
+		t.Log("Available plugins:")
+		for _, plugin := range plugins {
+			t.Logf("  - %s", plugin.GetName())
+		}
+	}
+}
+
 func TestPluginNames(t *testing.T) {
 	expectedPlugins := []string{
 		"argocd",
@@ -37,6 +61,7 @@ func TestPluginNames(t *testing.T) {
 		"load-balancer",
 		"nginx-ingress",
 		IngressName,
+		TLSName,
 	}
 
 	plugins, err := CreatePluginsList("dummy-kubeconfig", "192.168.1.100", "test-cluster")

--- a/internal/plugins/tls.go
+++ b/internal/plugins/tls.go
@@ -1,0 +1,370 @@
+package plugins
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/mrgb7/playground/internal/k8s"
+	"github.com/mrgb7/playground/pkg/logger"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	TLSName              = "tls"
+	TLSVersion           = "1.0.0"
+	TLSSecretName        = "local-ca-secret"
+	TLSClusterIssuerName = "local-ca-issuer"
+	CertValidityYears    = 10
+)
+
+type TLS struct {
+	KubeConfig  string
+	k8sClient   *k8s.K8sClient
+	ClusterName string
+	*BasePlugin
+}
+
+func NewTLS(kubeConfig, clusterName string) (*TLS, error) {
+	c, err := k8s.NewK8sClient(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s client: %w", err)
+	}
+	tls := &TLS{
+		KubeConfig:  kubeConfig,
+		k8sClient:   c,
+		ClusterName: clusterName,
+	}
+	tls.BasePlugin = NewBasePlugin(kubeConfig, tls)
+	return tls, nil
+}
+
+func (t *TLS) GetName() string {
+	return TLSName
+}
+
+func (t *TLS) Install(kubeConfig, clusterName string, ensure ...bool) error {
+	logger.Infoln("Installing TLS plugin for cluster: %s", clusterName)
+
+	if err := t.checkDependencies(); err != nil {
+		return fmt.Errorf("dependency check failed: %w", err)
+	}
+
+	caCert, caKey, err := t.generateCACertificate()
+	if err != nil {
+		return fmt.Errorf("failed to generate CA certificate: %w", err)
+	}
+
+	if err := t.storeCASecret(caCert, caKey); err != nil {
+		return fmt.Errorf("failed to store CA secret: %w", err)
+	}
+
+	if err := t.createClusterIssuer(); err != nil {
+		return fmt.Errorf("failed to create cluster issuer: %w", err)
+	}
+
+	if err := t.printTrustInstructions(caCert); err != nil {
+		return fmt.Errorf("failed to print trust instructions: %w", err)
+	}
+
+	logger.Successln("TLS plugin installed successfully")
+	return nil
+}
+
+func (t *TLS) Uninstall(kubeConfig, clusterName string, ensure ...bool) error {
+	logger.Infoln("Uninstalling TLS plugin")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := t.k8sClient.Clientset.CoreV1().Secrets(CertManagerNamespace).Delete(
+		ctx, TLSSecretName, metav1.DeleteOptions{})
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		logger.Warnln("Failed to delete CA secret: %v", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "cert-manager.io",
+		Version:  "v1",
+		Resource: "clusterissuers",
+	}
+	err = t.k8sClient.Dynamic.Resource(gvr).Delete(
+		ctx, TLSClusterIssuerName, metav1.DeleteOptions{})
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		logger.Warnln("Failed to delete cluster issuer: %v", err)
+	}
+
+	logger.Successln("TLS plugin uninstalled successfully")
+	return nil
+}
+
+func (t *TLS) Status() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := t.k8sClient.Clientset.CoreV1().Secrets(CertManagerNamespace).Get(
+		ctx, TLSSecretName, metav1.GetOptions{})
+	if err != nil {
+		return "TLS CA secret not found"
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "cert-manager.io",
+		Version:  "v1",
+		Resource: "clusterissuers",
+	}
+	_, err = t.k8sClient.Dynamic.Resource(gvr).Get(
+		ctx, TLSClusterIssuerName, metav1.GetOptions{})
+	if err != nil {
+		return "TLS cluster issuer not found"
+	}
+
+	return "TLS is configured and ready"
+}
+
+func (t *TLS) checkDependencies() error {
+	logger.Infoln("Checking TLS dependencies...")
+
+	certManager := NewCertManager(t.KubeConfig)
+	cmStatus := certManager.Status()
+	if !strings.Contains(cmStatus, "running") {
+		return fmt.Errorf("cert-manager is required but not installed/running. Status: %s", cmStatus)
+	}
+
+	logger.Successln("All dependencies satisfied")
+	return nil
+}
+
+func (t *TLS) generateCACertificate() ([]byte, []byte, error) {
+	logger.Infoln("Generating CA certificate for domain: *.%s.local", t.ClusterName)
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{fmt.Sprintf("%s Local CA", t.ClusterName)},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{""},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(CertValidityYears, 0, 0),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		DNSNames: []string{
+			fmt.Sprintf("*.%s.local", t.ClusterName),
+			fmt.Sprintf("%s.local", t.ClusterName),
+		},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	logger.Successln("CA certificate generated successfully")
+	return certPEM, keyPEM, nil
+}
+
+func (t *TLS) storeCASecret(caCert, caKey []byte) error {
+	logger.Infoln("Storing CA certificate in Kubernetes secret")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TLSSecretName,
+			Namespace: CertManagerNamespace,
+		},
+		Type: v1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"tls.crt": caCert,
+			"tls.key": caKey,
+		},
+	}
+
+	_, err := t.k8sClient.Clientset.CoreV1().Secrets(CertManagerNamespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil && strings.Contains(err.Error(), "already exists") {
+		_, err = t.k8sClient.Clientset.CoreV1().Secrets(CertManagerNamespace).Update(ctx, secret, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update existing CA secret: %w", err)
+		}
+		logger.Infoln("Updated existing CA secret")
+	} else if err != nil {
+		return fmt.Errorf("failed to create CA secret: %w", err)
+	} else {
+		logger.Successln("Created CA secret successfully")
+	}
+
+	return nil
+}
+
+func (t *TLS) createClusterIssuer() error {
+	logger.Infoln("Creating cluster issuer: %s", TLSClusterIssuerName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	clusterIssuer := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "ClusterIssuer",
+			"metadata": map[string]interface{}{
+				"name": TLSClusterIssuerName,
+			},
+			"spec": map[string]interface{}{
+				"ca": map[string]interface{}{
+					"secretName": TLSSecretName,
+				},
+			},
+		},
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "cert-manager.io",
+		Version:  "v1",
+		Resource: "clusterissuers",
+	}
+
+	_, err := t.k8sClient.Dynamic.Resource(gvr).Create(ctx, clusterIssuer, metav1.CreateOptions{})
+	if err != nil && strings.Contains(err.Error(), "already exists") {
+		_, err = t.k8sClient.Dynamic.Resource(gvr).Update(ctx, clusterIssuer, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update existing cluster issuer: %w", err)
+		}
+		logger.Infoln("Updated existing cluster issuer")
+	} else if err != nil {
+		return fmt.Errorf("failed to create cluster issuer: %w", err)
+	} else {
+		logger.Successln("Created cluster issuer successfully")
+	}
+
+	return nil
+}
+
+func (t *TLS) printTrustInstructions(caCert []byte) error {
+	logger.Infoln("Generating trust instructions for your operating system")
+
+	tempFile, err := os.CreateTemp("", fmt.Sprintf("%s-ca-*.crt", t.ClusterName))
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %w", err)
+	}
+	defer tempFile.Close()
+
+	if _, err := tempFile.Write(caCert); err != nil {
+		return fmt.Errorf("failed to write certificate to temp file: %w", err)
+	}
+
+	logger.Infoln("")
+	logger.Infoln("🔐 CA Certificate has been generated!")
+	logger.Infoln("📍 Temporary certificate file: %s", tempFile.Name())
+	logger.Infoln("")
+
+	switch runtime.GOOS {
+	case "darwin":
+		logger.Infoln("🍎 macOS Trust Instructions:")
+		logger.Infoln("sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain %s", tempFile.Name())
+		logger.Infoln("")
+		logger.Infoln("Alternative (GUI method):")
+		logger.Infoln("1. Double-click the certificate file to open Keychain Access")
+		logger.Infoln("2. Select 'System' keychain")
+		logger.Infoln("3. Find the certificate and double-click it")
+		logger.Infoln("4. Expand 'Trust' and set 'When using this certificate' to 'Always Trust'")
+
+	case "linux":
+		logger.Infoln("🐧 Linux Trust Instructions:")
+		logger.Infoln("sudo cp %s /usr/local/share/ca-certificates/%s-ca.crt", tempFile.Name(), t.ClusterName)
+		logger.Infoln("sudo update-ca-certificates")
+		logger.Infoln("")
+		logger.Infoln("For Firefox (if needed):")
+		logger.Infoln("Import the certificate manually in Firefox preferences > Privacy & Security > Certificates")
+
+	case "windows":
+		logger.Infoln("🪟 Windows Trust Instructions:")
+		logger.Infoln("certlm.msc")
+		logger.Infoln("1. Right-click 'Trusted Root Certification Authorities'")
+		logger.Infoln("2. Select 'All Tasks' > 'Import'")
+		logger.Infoln("3. Browse and select: %s", tempFile.Name())
+		logger.Infoln("4. Place in 'Trusted Root Certification Authorities' store")
+		logger.Infoln("")
+		logger.Infoln("Alternative (PowerShell as Administrator):")
+		logger.Infoln("Import-Certificate -FilePath \"%s\" -CertStoreLocation Cert:\\LocalMachine\\Root", tempFile.Name())
+
+	default:
+		logger.Infoln("📋 Generic Trust Instructions:")
+		logger.Infoln("Add the following certificate to your system's trusted CA store:")
+		logger.Infoln("Certificate file: %s", tempFile.Name())
+	}
+
+	logger.Infoln("")
+	logger.Infoln("🎯 Certificate Details:")
+	logger.Infoln("Domain: *.%s.local", t.ClusterName)
+	logger.Infoln("Validity: %d years", CertValidityYears)
+	logger.Infoln("Cluster Issuer: %s", TLSClusterIssuerName)
+	logger.Infoln("")
+	logger.Infoln("🚀 You can now use TLS certificates in your cluster!")
+	logger.Infoln("Example ingress annotation: cert-manager.io/cluster-issuer: %s", TLSClusterIssuerName)
+
+	logger.Infoln("")
+	logger.Infoln("📋 Certificate content (base64):")
+	certBase64 := base64.StdEncoding.EncodeToString(caCert)
+	logger.Infoln(certBase64)
+
+	return nil
+}
+
+func (t *TLS) GetNamespace() string {
+	return CertManagerNamespace
+}
+
+func (t *TLS) GetVersion() string {
+	return TLSVersion
+}
+
+func (t *TLS) GetChartName() string {
+	return ""
+}
+
+func (t *TLS) GetRepository() string {
+	return ""
+}
+
+func (t *TLS) GetRepoName() string {
+	return ""
+}
+
+func (t *TLS) GetChartValues() map[string]interface{} {
+	return make(map[string]interface{})
+}

--- a/internal/plugins/tls_test.go
+++ b/internal/plugins/tls_test.go
@@ -1,0 +1,94 @@
+package plugins
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestTLSPluginInterface(t *testing.T) {
+	plugin, err := NewTLS("dummy-kubeconfig", "test-cluster")
+	if err != nil {
+		t.Logf("K8s client creation failed (expected in test): %v", err)
+		return
+	}
+
+	if plugin.GetName() != TLSName {
+		t.Errorf("Expected plugin name '%s', got '%s'", TLSName, plugin.GetName())
+	}
+
+	if plugin.GetNamespace() != CertManagerNamespace {
+		t.Errorf("Expected namespace '%s', got '%s'", CertManagerNamespace, plugin.GetNamespace())
+	}
+
+	if plugin.GetVersion() != TLSVersion {
+		t.Errorf("Expected version '%s', got '%s'", TLSVersion, plugin.GetVersion())
+	}
+
+	if plugin.GetChartName() != "" {
+		t.Errorf("Expected empty chart name, got '%s'", plugin.GetChartName())
+	}
+
+	if plugin.GetRepository() != "" {
+		t.Errorf("Expected empty repository, got '%s'", plugin.GetRepository())
+	}
+
+	var _ Plugin = plugin
+}
+
+func TestTLSPluginConstants(t *testing.T) {
+	if TLSName != "tls" {
+		t.Errorf("Expected TLSName to be 'tls', got '%s'", TLSName)
+	}
+
+	if TLSVersion != "1.0.0" {
+		t.Errorf("Expected TLSVersion to be '1.0.0', got '%s'", TLSVersion)
+	}
+
+	if TLSSecretName != "local-ca-secret" {
+		t.Errorf("Expected TLSSecretName to be 'local-ca-secret', got '%s'", TLSSecretName)
+	}
+
+	if TLSClusterIssuerName != "local-ca-issuer" {
+		t.Errorf("Expected TLSClusterIssuerName to be 'local-ca-issuer', got '%s'", TLSClusterIssuerName)
+	}
+
+	if CertValidityYears != 10 {
+		t.Errorf("Expected CertValidityYears to be 10, got %d", CertValidityYears)
+	}
+}
+
+func TestTLSGenerateCACertificate(t *testing.T) {
+	plugin, err := NewTLS("dummy-kubeconfig", "test-cluster")
+	if err != nil {
+		t.Logf("K8s client creation failed (expected in test): %v", err)
+		return
+	}
+
+	caCert, caKey, err := plugin.generateCACertificate()
+	if err != nil {
+		t.Errorf("Failed to generate CA certificate: %v", err)
+		return
+	}
+
+	if len(caCert) == 0 {
+		t.Error("CA certificate is empty")
+	}
+
+	if len(caKey) == 0 {
+		t.Error("CA private key is empty")
+	}
+
+	if !containsPEMBlock(string(caCert), "CERTIFICATE") {
+		t.Error("CA certificate does not contain proper PEM block")
+	}
+
+	if !containsPEMBlock(string(caKey), "RSA PRIVATE KEY") {
+		t.Error("CA private key does not contain proper PEM block")
+	}
+}
+
+func containsPEMBlock(content, blockType string) bool {
+	return strings.Contains(content, fmt.Sprintf("-----BEGIN %s-----", blockType)) &&
+		strings.Contains(content, fmt.Sprintf("-----END %s-----", blockType))
+}


### PR DESCRIPTION
This PR introduces a comprehensive TLS plugin for SSL/TLS certificate management with automatic ArgoCD HTTPS integration. Features include self-signed CA generation, Kubernetes secret storage, cert-manager ClusterIssuer creation, OS-specific trust instructions, and seamless HTTP to HTTPS upgrade path. The ingress plugin now automatically detects and configures HTTPS when the TLS plugin is available.