### PR TITLE
Fix: Plugin installation skipping when dependencies are ready/configured

### DIFF
--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -105,9 +105,7 @@ func NewInstaller(plugin Plugin, kubeConfig, clusterName string) (installer.Inst
 // IsPluginInstalled checks if a plugin is installed based on its status
 func IsPluginInstalled(status string) bool {
 	statusLower := strings.ToLower(status)
-	return strings.Contains(statusLower, "running") ||
-		strings.Contains(statusLower, "configured") ||
-		strings.Contains(statusLower, "ready")
+	return strings.Contains(statusLower, "running")
 }
 
 // GetInstalledPlugins returns a list of currently installed plugin names


### PR DESCRIPTION
## Problem

There was an issue in dependency plugins where if the dependencies were already installed (in 'configured' or 'ready' state), the system would skip installing the plugin itself even when the user explicitly requested it.

## Root Cause

The `IsPluginInstalled()` function in `internal/plugins/utils.go` was considering plugins with status 'configured' and 'ready' as fully installed, causing the dependency validation to skip the target plugin installation.

## Solution

Modified `IsPluginInstalled()` to only consider 'running' status as truly installed:

- Removed 'configured' and 'ready' from the installed status check
- Only plugins with 'running' status are now considered installed
- This is safe because configuration plugins are idempotent - re-running configuration doesn't cause harm

## Benefits

- ✅ Respects user intent when explicitly requesting plugin installation
- ✅ Leverages idempotent nature of configuration operations
- ✅ Ensures target plugins are always processed when requested
- ✅ No side effects from re-configuring already configured plugins

## Testing

The fix ensures that when a user runs:
```bash
playground plugin add --name ingress --cluster my-cluster
```

The ingress plugin will be installed/configured even if its dependencies (load-balancer, nginx-ingress) are already in 'configured' state.

Fixes the dependency plugin installation issue.